### PR TITLE
Add auth token and server flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ To run the Gradio app with a profile 5 (a bit slower but requires only 6  GB of 
 python gradio_app --profile 5
 ```
 
+Additional useful flags:
+```bash
+python gradio_app --token YOUR_HF_TOKEN --server-name 0.0.0.0 --server-port 7860
+```
+
 You may check the mmgp git homepage if you want to design your own profiles (for instance to disable quantization).
 
 If you enjoy this applcitation, you will certainly appreciate  these ones:\


### PR DESCRIPTION
## Summary
- allow passing HF token to load gated models
- expose server host/port flags for gradio
- document new flags in README

## Testing
- `python -m py_compile gradio_app.py`
- `python -m py_compile src/gradio/gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684abcc2a184832582daac5264f038d7