### PR TITLE
Add NSFW image filter

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from src.flux.condition import Condition
 from src.flux.generate import seed_everything, generate
+from src.nsfw import zero_if_nsfw
 
 
 pipe = None
@@ -73,6 +74,7 @@ def process_image_and_text(image, text):
         height=512,
         width=512,
     ).images[0]
+    result_img = zero_if_nsfw(result_img)
 
     return result_img
 

--- a/src/gradio/gradio_app.py
+++ b/src/gradio/gradio_app.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from ..flux.condition import Condition
 from ..flux.generate import seed_everything, generate
+from ..nsfw import zero_if_nsfw
 
 pipe = None
 use_int8 = False
@@ -67,6 +68,7 @@ def process_image_and_text(image, text):
         height=512,
         width=512,
     ).images[0]
+    result_img = zero_if_nsfw(result_img)
 
     return result_img
 

--- a/src/nsfw.py
+++ b/src/nsfw.py
@@ -1,0 +1,39 @@
+from typing import Optional
+from PIL import Image
+import torch
+from transformers import pipeline
+
+_nsfw_pipeline: Optional[object] = None
+
+
+def load_nsfw_pipeline() -> object:
+    """Lazy load the NSFW detection pipeline."""
+    global _nsfw_pipeline
+    if _nsfw_pipeline is None:
+        _nsfw_pipeline = pipeline(
+            "image-classification",
+            model="Falconsai/nsfw_image_detection",
+            use_fast=True,
+            device=0 if torch.cuda.is_available() else -1,
+        )
+    return _nsfw_pipeline
+
+
+def is_nsfw_image(image: Image.Image) -> bool:
+    """Return True if the image is detected as NSFW."""
+    classifier = load_nsfw_pipeline()
+    result = classifier(image, top_k=5)
+    for entry in result:
+        label = entry["label"].lower()
+        score = entry["score"]
+        if label in {"nsfw", "porn", "sexy", "hentai"} and score > 0.4:
+            return True
+    return False
+
+
+def zero_if_nsfw(image: Image.Image) -> Image.Image:
+    """Return a black image if the given image is NSFW."""
+    if is_nsfw_image(image):
+        print("NSFW content detected, zeroing output")
+        return Image.new("RGB", image.size, (0, 0, 0))
+    return image


### PR DESCRIPTION
## Summary
- detect NSFW content in generated images
- zero out (return blank image) if NSFW detected
- apply filter in both Gradio apps

## Testing
- `python -m py_compile gradio_app.py src/gradio/gradio_app.py src/nsfw.py`

------
https://chatgpt.com/codex/tasks/task_e_684aedf9adf48325b6ca2ec98b47d917