### PR TITLE
Enable text-only generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ pip install -r requirements.txt
 1. Subject-driven generation: `examples/subject.ipynb`
 2. In-painting: `examples/inpainting.ipynb`
 3. Canny edge to image, depth to image, colorization, deblurring: `examples/spatial.ipynb`
+4. **Text-to-image**: leave the input image empty in the Gradio app
 
 
 

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -48,19 +48,22 @@ def init_pipeline(token=None):
                     )
 
 def process_image_and_text(image, text):
-    # center crop image
-    w, h, min_size = image.size[0], image.size[1], min(image.size)
-    image = image.crop(
-        (
-            (w - min_size) // 2,
-            (h - min_size) // 2,
-            (w + min_size) // 2,
-            (h + min_size) // 2,
+    conditions = None
+    if image is not None:
+        # center crop image
+        w, h, min_size = image.size[0], image.size[1], min(image.size)
+        image = image.crop(
+            (
+                (w - min_size) // 2,
+                (h - min_size) // 2,
+                (w + min_size) // 2,
+                (h + min_size) // 2,
+            )
         )
-    )
-    image = image.resize((512, 512))
+        image = image.resize((512, 512))
 
-    condition = Condition("subject", image, position_delta=(0, 32))
+        condition = Condition("subject", image, position_delta=(0, 32))
+        conditions = [condition]
 
     if pipe is None:
         init_pipeline(token=args.token)
@@ -68,7 +71,7 @@ def process_image_and_text(image, text):
     result_img = generate(
         pipe,
         prompt=text.strip(),
-        conditions=[condition],
+        conditions=conditions,
         num_inference_steps=8,
         height=512,
         width=512,

--- a/src/gradio/gradio_app.py
+++ b/src/gradio/gradio_app.py
@@ -42,19 +42,22 @@ def init_pipeline():
 
 
 def process_image_and_text(image, text):
-    # center crop image
-    w, h, min_size = image.size[0], image.size[1], min(image.size)
-    image = image.crop(
-        (
-            (w - min_size) // 2,
-            (h - min_size) // 2,
-            (w + min_size) // 2,
-            (h + min_size) // 2,
+    conditions = None
+    if image is not None:
+        # center crop image
+        w, h, min_size = image.size[0], image.size[1], min(image.size)
+        image = image.crop(
+            (
+                (w - min_size) // 2,
+                (h - min_size) // 2,
+                (w + min_size) // 2,
+                (h + min_size) // 2,
+            )
         )
-    )
-    image = image.resize((512, 512))
+        image = image.resize((512, 512))
 
-    condition = Condition("subject", image, position_delta=(0, 32))
+        condition = Condition("subject", image, position_delta=(0, 32))
+        conditions = [condition]
 
     if pipe is None:
         init_pipeline()
@@ -62,7 +65,7 @@ def process_image_and_text(image, text):
     result_img = generate(
         pipe,
         prompt=text.strip(),
-        conditions=[condition],
+        conditions=conditions,
         num_inference_steps=8,
         height=512,
         width=512,


### PR DESCRIPTION
## Summary
- allow the Gradio apps to run with no input image
- note in README that leaving the image blank enables text-to-image

## Testing
- `pytest -q`
- `python -m py_compile gradio_app.py src/gradio/gradio_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684aee88819483259af8f078bf4589af