### PR TITLE
Fix app metadata for social sharing

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -114,7 +114,7 @@ demo = gr.Interface(
     ],
     outputs=gr.Image(type="pil"),
     title="Hackathon Image Generator",
-
+    description="Hackathon Image Generator",
     examples=get_samples(),
 )
 

--- a/src/gradio/gradio_app.py
+++ b/src/gradio/gradio_app.py
@@ -108,6 +108,7 @@ demo = gr.Interface(
     ],
     outputs=gr.Image(type="pil"),
     title="Hackathon Image Generator",
+    description="Hackathon Image Generator",
     examples=get_samples(),
 )
 


### PR DESCRIPTION
## Summary
- add a `description` field to both Gradio apps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0dbeaa9083258e9783248d7f918d