### PR TITLE
Add persistent advanced options to Gradio UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+advanced_config.json


### PR DESCRIPTION
## Summary
- add config save/load helpers and ignore saved JSON
- toggle advanced options in new Blocks interface
- allow customizing number of steps, INT8 mode and transformer quantization
- keep selected options across sessions

## Testing
- `python -m py_compile gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b4ce8bd488325bc7cc92e9f625e52