### PR TITLE
Add root_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ python gradio_app --profile 5
 
 Additional useful flags:
 ```bash
-python gradio_app --token YOUR_HF_TOKEN --server-name 0.0.0.0 --server-port 7860
+python gradio_app --token YOUR_HF_TOKEN --server-name 0.0.0.0 --server-port 7860 --root_path /music
 ```
+`--root_path` allows the app to run under a specific context path, useful when
+serving behind a proxy.
 
 You may check the mmgp git homepage if you want to design your own profiles (for instance to disable quantization).
 

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -202,6 +202,7 @@ if __name__ == "__main__":
     parser.add_argument('--token', type=str, default=None, help="HuggingFace access token")
     parser.add_argument('--server-name', type=str, default="0.0.0.0", dest="server_name", help="Server name for gradio")
     parser.add_argument('--server-port', type=int, default=7860, dest="server_port", help="Server port for gradio")
+    parser.add_argument('--root_path', type=str, default="", dest="root_path", help="Context path for gradio")
 
     args = parser.parse_args()
 
@@ -210,4 +211,5 @@ if __name__ == "__main__":
         debug=True,
         server_name=args.server_name,
         server_port=args.server_port,
+        root_path=args.root_path,
     )


### PR DESCRIPTION
## Summary
- add `--root_path` option to `gradio_app.py`
- document `--root_path` usage in README

## Testing
- `pip install -q -r requirements.txt` *(fails: Operation cancelled)*


------
https://chatgpt.com/codex/tasks/task_e_684c0a166b5c8325ab932a8de27ba8b7